### PR TITLE
Optimized pipelineActivityClient

### DIFF
--- a/src/main/java/io/jenkins/x/client/kube/ClientHelper.java
+++ b/src/main/java/io/jenkins/x/client/kube/ClientHelper.java
@@ -1,46 +1,26 @@
 package io.jenkins.x.client.kube;
 
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 
-import java.util.List;
-
-/**
- */
 public class ClientHelper {
 
-    public static String JENKINS_CRD_GROUP = "jenkins.io";
-    public static String PIPELINE_ACTIVITIES_CRD_NAME = "pipelineactivities." + JENKINS_CRD_GROUP;
+    public static final String JENKINS_CRD_GROUP = "jenkins.io";
+    public static final String PIPELINE_ACTIVITIES_CRD_NAME = "pipelineactivities." + JENKINS_CRD_GROUP;
 
     public static NonNamespaceOperation<PipelineActivity, PipelineActivityList, DoneablePipelineActivities, Resource<PipelineActivity, DoneablePipelineActivities>> pipelineActivityClient(KubernetesClient client, String namespace) {
-        CustomResourceDefinitionList crds = client.customResourceDefinitions().list();
-        List<CustomResourceDefinition> crdsItems = crds.getItems();
-        CustomResourceDefinition runCRD = null;
-        for (CustomResourceDefinition crd : crdsItems) {
-            ObjectMeta metadata = crd.getMetadata();
-            if (metadata != null) {
-                String name = metadata.getName();
-                if (PIPELINE_ACTIVITIES_CRD_NAME.equals(name)) {
-                    runCRD = crd;
-                }
-            }
-        }
-        if (runCRD == null) {
-            runCRD = new CustomResourceDefinitionBuilder().
-                    withApiVersion("apiextensions.k8s.io/v1beta1").
-                    withNewMetadata().withName(PIPELINE_ACTIVITIES_CRD_NAME).endMetadata().
-                    withNewSpec().withGroup(JENKINS_CRD_GROUP).withVersion("v1").withScope("Namespaced").
-                    withNewNames().withKind("PipelineActivity").withShortNames("pipelineactivity", "activity", "act").withPlural("pipelineactivities").endNames().endSpec().
-                    build();
-
-            client.customResourceDefinitions().create(runCRD);
-        }
+        CustomResourceDefinition runCRD = new CustomResourceDefinitionBuilder().
+            withApiVersion("apiextensions.k8s.io/v1beta1").
+            withNewMetadata().withName(PIPELINE_ACTIVITIES_CRD_NAME).endMetadata().
+            withNewSpec().withGroup(JENKINS_CRD_GROUP).withVersion("v1").withScope("Namespaced").
+            withNewNames().withKind("PipelineActivity").withShortNames("pipelineactivity", "activity", "act").withPlural("pipelineactivities").endNames().endSpec().
+            build();
         return client.customResources(runCRD, PipelineActivity.class, PipelineActivityList.class, DoneablePipelineActivities.class).inNamespace(namespace);
     }
+
+    private ClientHelper() {}
 
 }


### PR DESCRIPTION
Currently `ClientHelper.pipelineActivityClient` quietly registers a CRD if there is not one already. This is contrary to the expectation that CRDs are already prepared before builds begin, and it could perhaps overwrite real CRDs which as of https://github.com/jenkins-x/jx/pull/2931 include schema validation.

Worse, it actually does a network operation (list CRDs) every time you call this method—which `BuildSyncRunListener.upsertBuild` in `jx-resources` does every time it is saving anything to a `PipelineActivity`! This is crazy because the only thing `DefaultKubernetesClient.customResources` does with its `crd` argument is to pass it to one constructor of `CustomResourceOperationsImpl`, which merely extracts a few fields from it—things that to the application code should be constants. From an actual JX installation:

```sh
kubectl get customresourcedefinitions.apiextensions.k8s.io pipelineactivities.jenkins.io -o json | jq -r '.spec.group, .spec.version, .spec.names.plural, .spec.scope'
```

produces

```
jenkins.io
v1
pipelineactivities
Namespaced
```

like this builder uses.

Compatibility confirmed by using this patch in an in-cluster functional test that expects `BuildSyncRunListener` to be operational.