### PR TITLE
Upgrade fabric8io/kubernetes-client dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <kubernetes-client.version>3.1.12</kubernetes-client.version>
+    <kubernetes-client.version>4.1.3</kubernetes-client.version>
 
     <assertj.core.version>2.4.1</assertj.core.version>
 


### PR DESCRIPTION
Picks up the [latest release](https://github.com/fabric8io/kubernetes-client/releases/tag/v4.1.3) including my https://github.com/fabric8io/kubernetes-client/pull/1354 and https://github.com/fabric8io/kubernetes-client/pull/1224 + https://github.com/fabric8io/kubernetes-client/pull/1348.

I _would_ like to switch the whole library to use `kubernetes-client/java` but that is obviously more disruptive whereas this should be a drop-in replacement.